### PR TITLE
Fix vertical padding calculation when PNG height is smaller than MacPaint

### DIFF
--- a/formats.py
+++ b/formats.py
@@ -128,9 +128,9 @@ class PNGFile(ImageConverter):
         if self.height > MacPaintFile.HEIGHT:
             rows = rows[:MacPaintFile.HEIGHT]
         if self.height < MacPaintFile.HEIGHT:
-            add_rows = MacPaintFile.HEIGHT - height
+            add_rows = MacPaintFile.HEIGHT - self.height
             for _ in range(add_rows):
-                rows.append([MacPaintFile.WHITE] * MacPaintFile.WIDTH)
+                rows.append([MacPaintFile.WHITE] * self.width)
         if self.width > MacPaintFile.WIDTH:
             rows = [row[:MacPaintFile.WIDTH] for row in rows]
         if self.width < MacPaintFile.WIDTH:


### PR DESCRIPTION
Here is the input PNG that uncovered the bug:
![input](https://github.com/user-attachments/assets/9f303feb-7bf8-4fb7-b6b8-710a3f434307)
